### PR TITLE
added GNRMC to support GLONASS enabled devices

### DIFF
--- a/TinyGPS++.cpp
+++ b/TinyGPS++.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdlib.h>
 
 #define _GPRMCterm   "GPRMC"
+#define _GNRMCterm   "GNRMC"
 #define _GPGGAterm   "GPGGA"
 
 TinyGPSPlus::TinyGPSPlus()
@@ -207,7 +208,7 @@ bool TinyGPSPlus::endOfTermHandler()
   // the first term determines the sentence type
   if (curTermNumber == 0)
   {
-    if (!strcmp(term, _GPRMCterm))
+    if (!strcmp(term, _GPRMCterm) || !strcmp(term, _GNRMCterm))
       curSentenceType = GPS_SENTENCE_GPRMC;
     else if (!strcmp(term, _GPGGAterm))
       curSentenceType = GPS_SENTENCE_GPGGA;


### PR DESCRIPTION
I've been using TinyGPS++ to connect to the Quectel L76 module, which supports GLONASS. While it does output GPGGA sentences for receivers that don't expect GNGGA ones, it doesn't do this for the GPRMC/GNRMC sentences. This minor tweak enabled me to read speed and course from my device.
