### PR TITLE
Location average functionality added

### DIFF
--- a/TinyGPS++.cpp
+++ b/TinyGPS++.cpp
@@ -527,3 +527,11 @@ void TinyGPSLocationAverage::commit() {
    valid = updated = true;
 }
 
+void TinyGPSLocationAverage::resize(int max) {
+   step = 0;
+   max_hist = max;
+   valid = updated = false;
+   latArray = new double[max];
+   lngArray = new double[max];
+}
+

--- a/TinyGPS++.cpp
+++ b/TinyGPS++.cpp
@@ -506,30 +506,6 @@ double RawDegrees::toDouble() {
     return negative ? -ret : ret;
 }
 
-void RawDegrees::operator += (const RawDegrees& rawdeg) {
-   int16_t deg_int = this->negative ? -this->deg : this->deg + \
-      rawdeg.negative ? -rawdeg.deg : rawdeg.deg;
-   int32_t billionth_int = this->negative ? -this->billionths : this->billionths + \
-      rawdeg.negative ? -rawdeg.billionths : rawdeg.billionths;
-   if (billionth_int >= 1000000000) {
-      billionth_int -= 1000000000;
-      deg_int++;
-   }
-   else if (billionth_int <= -1000000000) {
-      billionth_int += 1000000000;
-      deg_int--;
-   }
-   double new_deg = deg_int + billionth_int / 1000000000.0;
-   boolean new_negative = new_deg < 0;
-   this->deg = new_negative ? -deg_int : deg_int;
-   this->billionths = new_negative ? -billionth_int : billionth_int;
-}
-
-void RawDegrees::operator /= (int divisor) {
-   this->deg /= divisor;
-   this->billionths /= divisor;
-}
-
 void TinyGPSLocationAverage::update(double lat, double lng) {
    latArray[step] = lat;
    lngArray[step++] = lng;

--- a/TinyGPS++.h
+++ b/TinyGPS++.h
@@ -62,20 +62,24 @@ public:
    uint32_t age() const    { return valid ? millis() - lastCommitTime : (uint32_t)ULONG_MAX; }
    double lat() { updated = false; return avlat; }
    double lng() { updated = false; return avlng; }
-   void update(double lat, double lng);
 
-   TinyGPSLocationAverage(int max)
-   : valid(false)
-   , updated(false)
-   , step(0)
-   , max_hist(max)
-   {}
+   void resize(int max)
+   {
+	   step = 0;
+	   max_hist = max;
+	   valid = updated = false;
+	   latArray = new double[max];
+	   lngArray = new double[max];
+   }
+
+   TinyGPSLocationAverage(int max) : avlat(0), avlng(0) { resize(max); }
 
 private:
    bool valid, updated;
-   double latArray[10], lngArray[10], avlat, avlng;
+   double *latArray, *lngArray, avlat, avlng;
    uint32_t lastCommitTime, step, max_hist;
    void commit();
+   void update(double lat, double lng);
 };
 
 struct TinyGPSLocation

--- a/TinyGPS++.h
+++ b/TinyGPS++.h
@@ -64,8 +64,7 @@ public:
    uint32_t age() const    { return valid ? millis() - lastCommitTime : (uint32_t)ULONG_MAX; }
    double lat() { updated = false; return avlat; }
    double lng() { updated = false; return avlng; }
-   void add_lat(double lat);
-   void add_lng(double lng);
+   void update(double lat, double lng);
 
    TinyGPSLocationAverage(int max)
    : valid(false)
@@ -78,7 +77,7 @@ private:
    bool valid, updated;
    double latArray[10], lngArray[10], avlat, avlng;
    uint32_t lastCommitTime, step, max_hist;
-//   void commit();
+   void commit();
 };
 
 struct TinyGPSLocation
@@ -92,9 +91,10 @@ public:
    const RawDegrees &rawLng()     { updated = false; return rawLngData; }
    double lat();
    double lng();
-//   RawDegrees average;
+   TinyGPSLocationAverage average = TinyGPSLocationAverage(10);
 
-   TinyGPSLocation(): valid(false), updated(false), step(0), max_hist(5) {}
+   TinyGPSLocation() : valid(false), updated(false)
+   {}
 
 private:
    bool valid, updated;

--- a/TinyGPS++.h
+++ b/TinyGPS++.h
@@ -49,8 +49,6 @@ public:
    RawDegrees() : deg(0), billionths(0), negative(false) {}
 
    double toDouble();
-   void operator += (const RawDegrees& rawdeg); // Overload += (for sum calculation).
-   void operator /= (int divisor); // Overload += (for mean calculation).
 };
 
 struct TinyGPSLocation;
@@ -99,7 +97,7 @@ public:
 private:
    bool valid, updated;
    RawDegrees rawLatData, rawLngData, rawNewLatData, rawNewLngData;
-   uint32_t lastCommitTime, step, max_hist;
+   uint32_t lastCommitTime;
    void commit();
    void setLatitude(const char *term);
    void setLongitude(const char *term);

--- a/TinyGPS++.h
+++ b/TinyGPS++.h
@@ -51,8 +51,6 @@ public:
    double toDouble();
 };
 
-struct TinyGPSLocation;
-
 struct TinyGPSLocationAverage
 {
    friend struct TinyGPSLocation;
@@ -62,17 +60,10 @@ public:
    uint32_t age() const    { return valid ? millis() - lastCommitTime : (uint32_t)ULONG_MAX; }
    double lat() { updated = false; return avlat; }
    double lng() { updated = false; return avlng; }
+   void resize(int max);
 
-   void resize(int max)
-   {
-	   step = 0;
-	   max_hist = max;
-	   valid = updated = false;
-	   latArray = new double[max];
-	   lngArray = new double[max];
-   }
-
-   TinyGPSLocationAverage(int max) : avlat(0), avlng(0) { resize(max); }
+   TinyGPSLocationAverage(int max) : avlat(0), avlng(0)
+   { resize(max); }
 
 private:
    bool valid, updated;
@@ -93,6 +84,7 @@ public:
    const RawDegrees &rawLng()     { updated = false; return rawLngData; }
    double lat();
    double lng();
+
    TinyGPSLocationAverage average = TinyGPSLocationAverage(10);
 
    TinyGPSLocation() : valid(false), updated(false)

--- a/examples/LocationAverage/LocationAverage.ino
+++ b/examples/LocationAverage/LocationAverage.ino
@@ -1,0 +1,119 @@
+#include <TinyGPS++.h>
+/* 
+   This sample sketch should be the second you try out when you are testing a TinyGPS++
+   (TinyGPSPlus) installation.  In normal use, you feed TinyGPS++ objects characters from
+   a serial NMEA GPS device, but this example uses static strings for simplicity.
+
+   It also demonstrates the average location ability.
+*/
+
+// A sample NMEA stream.
+const char *gpsStream =
+  "$GPRMC,045103.000,A,3014.1984,N,09749.2872,W,0.67,161.46,030913,,,A*7C\r\n"
+  "$GPGGA,045104.000,3014.1985,N,09749.2873,W,1,09,1.2,211.6,M,-22.5,M,,0000*62\r\n"
+  "$GPRMC,045200.000,A,3014.3820,N,09748.9514,W,36.88,65.02,030913,,,A*77\r\n"
+  "$GPGGA,045201.000,3014.3864,N,09748.9411,W,1,10,1.2,200.8,M,-22.5,M,,0000*6C\r\n"
+  "$GPRMC,045251.000,A,3014.4275,N,09749.0626,W,0.51,217.94,030913,,,A*7D\r\n"
+  "$GPGGA,045252.000,3014.4273,N,09749.0628,W,1,09,1.3,206.9,M,-22.5,M,,0000*6F\r\n";
+
+// The TinyGPS++ object
+TinyGPSPlus gps;
+
+void setup()
+{
+  SerialUSB.begin(9600);
+
+  while(!SerialUSB);
+
+  // default 10. This function is dynamic, which means it can be called during runtime. 
+  // Thus it is resized later in `void displayInfo()`
+  gps.location.average.resize(2);
+
+  SerialUSB.println(F("LocationAverage.ino"));
+  SerialUSB.println(F("Basic demonstration of TinyGPS++ and average location (no device needed)"));
+  SerialUSB.print(F("Testing TinyGPS++ library v. ")); SerialUSB.println(TinyGPSPlus::libraryVersion());
+  SerialUSB.println(F("by Mikal Hart, Average Location added by Daniel Robinson"));
+  SerialUSB.println();
+
+  while (*gpsStream)
+    if (gps.encode(*gpsStream++))
+      displayInfo();
+
+  SerialUSB.println();
+  SerialUSB.println(F("Done."));
+  
+  pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop()
+{
+  // blink LED
+  static int time_now = 0, led_enabled = 0;
+  if (millis() - time_now > 1000) {
+    led_enabled ^= 1;
+    digitalWrite(LED_BUILTIN, led_enabled);
+    time_now = millis();
+    SerialUSB.println(time_now);
+  }
+}
+
+void displayInfo()
+{
+  SerialUSB.print(F("Location: ")); 
+  if (gps.location.isValid())
+  {
+    SerialUSB.print(gps.location.lat(), 9);
+    SerialUSB.print(F(","));
+    SerialUSB.print(gps.location.lng(), 9);
+  }
+  else
+  {
+    SerialUSB.print(F("INVALID"));
+  }
+
+  SerialUSB.print(F("  Date/Time: "));
+  if (gps.date.isValid())
+  {
+    SerialUSB.print(gps.date.month());
+    SerialUSB.print(F("/"));
+    SerialUSB.print(gps.date.day());
+    SerialUSB.print(F("/"));
+    SerialUSB.print(gps.date.year());
+  }
+  else
+  {
+    SerialUSB.print(F("INVALID"));
+  }
+
+  SerialUSB.print(F(" "));
+  if (gps.time.isValid())
+  {
+    if (gps.time.hour() < 10) SerialUSB.print(F("0"));
+    SerialUSB.print(gps.time.hour());
+    SerialUSB.print(F(":"));
+    if (gps.time.minute() < 10) SerialUSB.print(F("0"));
+    SerialUSB.print(gps.time.minute());
+    SerialUSB.print(F(":"));
+    if (gps.time.second() < 10) SerialUSB.print(F("0"));
+    SerialUSB.print(gps.time.second());
+    SerialUSB.print(F("."));
+    if (gps.time.centisecond() < 10) SerialUSB.print(F("0"));
+    SerialUSB.print(gps.time.centisecond());
+  }
+  else
+  {
+    SerialUSB.print(F("INVALID"));
+  }
+
+  SerialUSB.println();
+
+  if (gps.location.average.isUpdated())
+  {
+    gps.location.average.resize(4); // take note of this
+    SerialUSB.print(F("Average Location: ")); 
+    SerialUSB.print(gps.location.average.lat(), 9);
+    SerialUSB.print(F(","));
+    SerialUSB.println(gps.location.average.lng(), 9);
+    SerialUSB.println();
+  }
+}


### PR DESCRIPTION
First off, it doesn't have to be version 0.96.

Secondly, please let me know if you'd like to change anything.

In the spirit of this library, the location average methods are very similar to the location methods except for the dynamic resize ability.

Accessing the latitude is as simple as 
`gps.location.average.lat()`

Resizing (default 10) is as simple as:
`gps.location.average.resize(300)`

This is the output of the LocationAverage.ino example:

`
LocationAverage.ino                                                           
Basic demonstration of TinyGPS++ and average location (no device needed)      
Testing TinyGPS++ library v. 0.96                                             
by Mikal Hart, Average Location added by Daniel Robinson

Location: 30.236640000,-97.821453333  Date/Time: 9/3/2013 04:51:03.00
Location: 30.236641667,-97.821455000  Date/Time: 9/3/2013 04:51:04.00
Average Location: 30.236640833,-97.821454166
                                                                                
Location: 30.239700000,-97.815856667  Date/Time: 9/3/2013 04:52:00.00         
Location: 30.239773333,-97.815685000  Date/Time: 9/3/2013 04:52:01.00         
Location: 30.240458333,-97.817710000  Date/Time: 9/3/2013 04:52:51.00         
Location: 30.240455000,-97.817713333  Date/Time: 9/3/2013 04:52:52.00         
Average Location: 30.240096666,-97.816741250
`