### PR TITLE
fix argument for TinyGPSPlus::cardinal(double)

### DIFF
--- a/examples/FullExample/FullExample.ino
+++ b/examples/FullExample/FullExample.ino
@@ -42,7 +42,7 @@ void loop()
   printFloat(gps.altitude.meters(), gps.altitude.isValid(), 7, 2);
   printFloat(gps.course.deg(), gps.course.isValid(), 7, 2);
   printFloat(gps.speed.kmph(), gps.speed.isValid(), 6, 2);
-  printStr(gps.course.isValid() ? TinyGPSPlus::cardinal(gps.course.value()) : "*** ", 6);
+  printStr(gps.course.isValid() ? TinyGPSPlus::cardinal(gps.course.deg()) : "*** ", 6);
 
   unsigned long distanceKmToLondon =
     (unsigned long)TinyGPSPlus::distanceBetween(


### PR DESCRIPTION
`TinyGPSPlus::cardinal(double x)` assumes argument of _degrees_ (i.e. from `TinyGPSCourse::deg()`).
(This example was passing `int32_t` of milli-degrees from `TinyGPSCourse`'s inherited function `TinyGPSDecimal::value()`.) :smiley:

Thank you for the well-written library and useful examples!