### PR TITLE
Fix -Wstringop-truncation warning.

### DIFF
--- a/src/TinyGPS++.cpp
+++ b/src/TinyGPS++.cpp
@@ -484,7 +484,8 @@ void TinyGPSCustom::commit()
 
 void TinyGPSCustom::set(const char *term)
 {
-   strncpy(this->stagingBuffer, term, sizeof(this->stagingBuffer));
+   strncpy(this->stagingBuffer, term, sizeof(this->stagingBuffer) - 1);
+   stagingBuffer[sizeof(stagingBuffer) - 1] = 0;
 }
 
 void TinyGPSPlus::insertCustom(TinyGPSCustom *pElt, const char *sentenceName, int termNumber)


### PR DESCRIPTION
This fixes a warning I encountered when cross compiling for Raspberry Pi. If `term` is longer than `stagingBuffer` it won't be 0-terminated.

Also, fun fact. `strncpy` always copies the specified bytes. If the source is shorter than that it pads the rest with 0. TIL.

> If the length of src is less than n, strncpy() writes additional null bytes to dest to ensure that a total of n bytes are written.

For the low end chips like AVR it could be worth adding a custom `strncpy` which guarantees termination without the overhead of filling the entire buffer.

```
char* tinygps_strncpy(char *dest, const char *src, size_t n) {
   size_t i;
   for (i = 0; i < n && src[i] != '\0'; i++)
      dest[i] = src[i];

   dest[i - 1] = 0;
   return dest;
}
```