### PR TITLE
Enable building for platforms other than Arduino.

### DIFF
--- a/src/TinyGPS++.cpp
+++ b/src/TinyGPS++.cpp
@@ -27,6 +27,41 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <ctype.h>
 #include <stdlib.h>
 
+#ifndef ARDUINO
+// Enable use of this library on non-Arduino targets by defining symbols that are
+// normally provided by the Arduino standard headers (Arduino.h/WProgram.h).
+
+typedef uint8_t byte;
+
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+#define PI           (M_PI)
+#define HALF_PI      (M_PI / 2.0)
+#define TWO_PI       (M_PI * 2.0)
+#define DEG_TO_RAD   (M_PI / 180.0)
+#define RAD_TO_DEG   (180.0 / M_PI)
+
+#define radians(deg) ((deg)*DEG_TO_RAD)
+#define degrees(rad) ((rad)*RAD_TO_DEG)
+#define sq(x)        ((x)*(x))
+
+
+#include <chrono>
+
+unsigned long millis()
+{
+   // Standards-compliant replacement for Arduino-specific millis() function:
+   // uses C++11's std::chrono::steady_clock, which is roughly equivalent
+   // to clock_gettime(CLOCK_MONOTONIC, ...) in POSIX C.
+    using namespace std::chrono;
+    const auto now = time_point_cast<milliseconds>(system_clock::now());
+    const auto ms  = now.time_since_epoch().count();
+    return static_cast<unsigned long>(ms);
+}
+#endif  // !ARDUINO
+
 #define _GPRMCterm   "GPRMC"
 #define _GPGGAterm   "GPGGA"
 #define _GNRMCterm   "GNRMC"

--- a/src/TinyGPS++.h
+++ b/src/TinyGPS++.h
@@ -24,12 +24,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef __TinyGPSPlus_h
 #define __TinyGPSPlus_h
 
-#if defined(ARDUINO) && ARDUINO >= 100
-#include "Arduino.h"
+#if defined (ARDUINO)
+#if ARDUINO >= 100
+   #include "Arduino.h"
 #else
-#include "WProgram.h"
-#endif
-#include <limits.h>
+   #include "WProgram.h"
+#endif  // ARDUINO >= 100
+#else
+   #include <cstdint>
+   #include <limits.h>
+
+   unsigned long millis();
+#endif  // ARDUINO
 
 #define _GPS_VERSION "1.0.2" // software version of this library
 #define _GPS_MPH_PER_KNOT 1.15077945


### PR DESCRIPTION
With a few minor tweaks, this library can be made more universal, so that it can be built for platforms other than Arduino. This vastly increases the usefulness of the library, without compromising any functionality.

This merge request contains the changes needed to make the library universal enough to be built for any platform with a standards-compliant C++11 compiler. These changes are as minimally-invasive as possible, and remain fully backwards-compatible (as long as `ARDUINO` is #defined, the original code will be used).