### PR TITLE
Custom objects: more convenient parsing of sentence name (was: Update TinyGPS++.cpp)

### DIFF
--- a/src/TinyGPS++.cpp
+++ b/src/TinyGPS++.cpp
@@ -217,8 +217,14 @@ bool TinyGPSPlus::endOfTermHandler()
       curSentenceType = GPS_SENTENCE_OTHER;
 
     // Any custom candidates of this sentence type?
-    for (customCandidates = customElts; customCandidates != NULL && strcmp(customCandidates->sentenceName, term) < 0; customCandidates = customCandidates->next);
-    if (customCandidates != NULL && strcmp(customCandidates->sentenceName, term) > 0)
+    // for (customCandidates = customElts; customCandidates != NULL && strcmp(customCandidates->sentenceName, term) < 0; customCandidates = customCandidates->next);
+    // if (customCandidates != NULL && strcmp(customCandidates->sentenceName, term) > 0)
+    //   customCandidates = NULL;
+    
+    // modification: look if string is present in string, not for equality
+    // this allows to use the full NMEA sentence identifiers or the generic sentence names (
+    for (customCandidates = customElts; customCandidates != NULL && !strstr(term, customCandidates->sentenceName); customCandidates = customCandidates->next);
+    if (customCandidates != NULL && !strstr(term,customCandidates->sentenceName))
        customCandidates = NULL;
 
     return false;


### PR DESCRIPTION
Hi Mikal,

I am using your "TinyGPS++" library to create a generic NMEA info display for use on a boat. Thank you for your great work, the library works very well!

Nevertheless I 'd ask you for a modification in the handling of custom NMEA sentences. :-)

Background:
In the present version V1.0.2 the parser looks at the complete first term in a NMEA sentence - even though the actual identification of the NMEA sentence is only done in the last three characters of the first term, the first two characters are a manufacturer code.

Example: These two NMEA sentences "VHW" contain the same information, but differ in the first two characters ("II" vs. "VW"), (and the checksum):

$IIVHW,,,307.,M,08.08,N,14.97,K*10
$VWVHW,,,307.,M,08.08,N,14.97,K*11

To parse the data using TinyGPS++ two separate definitions are needed:

TinyGPSCustom nmeaLogSpeedKmh(gps, "GPVHW", 7);             // Log Speed in km/h
TinyGPSCustom nmeaLogSpeedKmh(gps, "IIVHW", 7);             // Log Speed in km/h

This makes it almost impossible to write a generic code, that works regardless of the manufacturer ID in the first two characters.

My request: The parser in TinyGPS++ can easily be modified to look only at the relevant sentence identifiers (VHW in the example above) and use this definition:
TinyGPSCustom nmeaLogSpeedKmh(gps, "VHW", 7);             // Log Speed in km/h

With that change, the "VHV" data set can be extracted from NMEA sentences by any manufacturer without changing the software.

The only modification required is in line 223 of "tinygps.cpp", replacing "!strstr" for "strcmp", see - code change