### PR TITLE
Fixes stringop-truncation on set method

### DIFF
--- a/src/TinyGPS++.cpp
+++ b/src/TinyGPS++.cpp
@@ -484,7 +484,7 @@ void TinyGPSCustom::commit()
 
 void TinyGPSCustom::set(const char *term)
 {
-   strncpy(this->stagingBuffer, term, sizeof(this->stagingBuffer));
+   strncpy(this->stagingBuffer, term, sizeof(this->stagingBuffer) - 1);
 }
 
 void TinyGPSPlus::insertCustom(TinyGPSCustom *pElt, const char *sentenceName, int termNumber)


### PR DESCRIPTION
i created a issue about this (https://github.com/mikalhart/TinyGPSPlus/issues/108)  and this is the pr for the fix, hope you can check it and aprove it in case it´s ok.
Thanks!