### PR TITLE
Added overloaded encode function which can accept a character array

### DIFF
--- a/src/TinyGPS++.cpp
+++ b/src/TinyGPS++.cpp
@@ -97,6 +97,16 @@ bool TinyGPSPlus::encode(char c)
   return false;
 }
 
+bool TinyGPSPlus::encode(char* c, size_t len)
+{
+  bool bRet = false;
+
+  for(int i = 0; i < len; i++)
+    bRet |= encode(c[i]);
+
+  return bRet; // Return true if one of the characters resulted in a valid sentence
+}
+
 //
 // internal utilities
 //

--- a/src/TinyGPS++.h
+++ b/src/TinyGPS++.h
@@ -221,6 +221,7 @@ class TinyGPSPlus
 public:
   TinyGPSPlus();
   bool encode(char c); // process one character received from GPS
+  bool encode(char* c, size_t len); // process len characters received from GPS
   TinyGPSPlus &operator << (char c) {encode(c); return *this;}
 
   TinyGPSLocation location;


### PR DESCRIPTION
Existing encode function accepts 1 character input at a time. As a result, most examples using this library include a statement such as this

```
void loop(void)
{
  gps.encode( Serial2.read() );
  ...
}
```

Which reads from the GPS sensor serial interface, once character at a time.

Although, reading multiple characters from the GPS sensor serial interface at once is significantly more efficient. Therefore, adding an encode function which can take a collection of characters as input is very helpful. This pull request adds that overloaded encode function to the TinyGPSPlus library.

Following is a snippet from my arduino_ide project which uses the modified TinyGPSPlus library

#define SER_READ_BUF_SIZE 256
char gSerBuf[SER_READ_BUF_SIZE];

void loop(void)
{
  size_t serBufReadLen = Serial2.read( gSerBuf, SER_READ_BUF_SIZE );
  if( serBufReadLen > 0 && serBufReadLen < SER_READ_BUF_SIZE )
    gps.encode( gSerBuf, gSerBufReadLen );
  ...

  delay(10);
}

After this change, the code runs significantly faster and more efficiently.