### PR TITLE
Fix strncpy warning

### DIFF
--- a/src/TinyGPS++.cpp
+++ b/src/TinyGPS++.cpp
@@ -485,6 +485,7 @@ void TinyGPSCustom::commit()
 void TinyGPSCustom::set(const char *term)
 {
    strncpy(this->stagingBuffer, term, sizeof(this->stagingBuffer));
+   this->stagingBuffer[sizeof(this->stagingBuffer) - 1] = '\0';
 }
 
 void TinyGPSPlus::insertCustom(TinyGPSCustom *pElt, const char *sentenceName, int termNumber)


### PR DESCRIPTION
```bash
TinyGPSPlus/src/TinyGPS++.cpp: In member function 'void TinyGPSCustom::set(const char*)':
TinyGPSPlus/src/TinyGPS++.cpp:488:11: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 16 equals destination size [-Wstringop-truncation]
  488 |    strncpy(this->stagingBuffer, term, sizeof(this->stagingBuffer));
      |    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```