### PR TITLE
Fixes to facilitate building directly on ESP-IDF

### DIFF
--- a/library.json
+++ b/library.json
@@ -17,6 +17,9 @@
        "maintainer": true
     }
   ],
-  "frameworks": "arduino",
-  "platforms": "*"
+  "frameworks": "*",
+  "platforms": "*",
+  "build": {
+    "includeDir": "src"
+  }
 }

--- a/src/TinyGPS++.cpp
+++ b/src/TinyGPS++.cpp
@@ -30,6 +30,30 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define _RMCterm "RMC"
 #define _GGAterm "GGA"
 
+#ifndef ARDUINO
+// Enable use of this library on non-Arduino targets by defining symbols that are
+// normally provided by the Arduino standard headers (Arduino.h/WProgram.h).
+
+typedef uint8_t byte;
+
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+#define PI           (M_PI)
+#define HALF_PI      (M_PI / 2.0)
+#define TWO_PI       (M_PI * 2.0)
+#define DEG_TO_RAD   (M_PI / 180.0)
+#define RAD_TO_DEG   (180.0 / M_PI)
+
+#define radians(deg) ((deg)*DEG_TO_RAD)
+#define degrees(rad) ((rad)*RAD_TO_DEG)
+#define sq(x)        ((x)*(x))
+
+
+#include <chrono>
+#endif  // !ARDUINO
+
 #if !defined(ARDUINO) && !defined(__AVR__)
 // Alternate implementation of millis() that relies on std
 unsigned long millis()

--- a/src/TinyGPS++.h
+++ b/src/TinyGPS++.h
@@ -26,8 +26,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef __TinyGPSPlus_h
 #define __TinyGPSPlus_h
 
-#include <inttypes.h>
+#if defined (ARDUINO)
+#if ARDUINO >= 100
 #include "Arduino.h"
+#else
+#include "WProgram.h"
+#endif  // ARDUINO >= 100
+#else
+#include <cstdint>
+
+unsigned long millis();
+#endif  // ARDUINO
 #include <limits.h>
 
 #define _GPS_VERSION "1.1.0" // software version of this library


### PR DESCRIPTION
This PR implements patches to permit building ESPHome configurations with this library when using ESP-IDF (instead of Arduino) as the framework. This results in smaller binaries, which is particularly important due to the notable size increase associated with Arduino 3.x. Here's the results from our build tests for the original ESP32:

- Arduino:
  ```
  RAM:   [=         ]   6.4% (used 20900 bytes from 327680 bytes)
  Flash: [==        ]  19.7% (used 361164 bytes from 1835008 bytes)
  ```

- IDF:
  ```
  RAM:   [          ]   3.6% (used 11780 bytes from 327680 bytes)
  Flash: [=         ]  14.7% (used 269864 bytes from 1835008 bytes)
  ```

Some of these changes were in #69 but it appears that they were not merged correctly and/or additional changes were made after merging them, at least based on what I see in https://github.com/mikalhart/TinyGPSPlus/commit/c093432911f5e1a2f54844976d3a14ec212f2403

I've created additional (ESPHome) tests to verify these changes work when built with ESPHome configurations using both Arduino and IDF; see esphome/esphome#9728